### PR TITLE
Support invalid UTF-8 in redis data

### DIFF
--- a/src/formatter/json.rs
+++ b/src/formatter/json.rs
@@ -3,7 +3,6 @@ use crate::formatter::Formatter;
 use crate::types::{EncodingType, RdbResult};
 use std::io;
 use std::io::Write;
-use std::str;
 
 pub struct JSON {
     out: Box<dyn Write + 'static>,
@@ -29,7 +28,7 @@ impl JSON {
 }
 
 fn encode_to_ascii(value: &[u8]) -> String {
-    let s = unsafe { str::from_utf8_unchecked(value) };
+    let s = String::from_utf8_lossy(value);
     serde_json::to_string(&s).unwrap()
 }
 


### PR DESCRIPTION
If there is invalid UTF-8 in the data, we previously would panic when
attempting to serialize it to a JSON. This change replaces invalid UTF-8
with the UTF-8 replacement character. This results in decreased
performance when we need to allocate a new string, but this is
preferrable to panicking.